### PR TITLE
Cleanup: fix go tool vet warnning

### DIFF
--- a/example/example_struct/example_struct.go
+++ b/example/example_struct/example_struct.go
@@ -12,7 +12,7 @@ import (
 
 type Var struct {
 	Expiry time.Time `json:"expiry,omitempty"`
-	ID     string    `json:"id",omitempty`
+	ID     string    `json:"id,omitempty"`
 }
 
 // We will order the node by `Time`


### PR DESCRIPTION
go tool vet complains:
struct field tag `json:"id",omitempty` not compatible with
reflect.StructTag.Get: bad syntax for struct tag pair

Signed-off-by: Hu Keping <hukeping@huawei.com>