### PR TITLE
Feat: add Go 1.18+ generic implementation with better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,64 @@ which will be store in the Red-Black tree, here are some examples.
 		fmt.Printf("%+v\n", i)
 		return true
 	}
+
+## Type-Safe Generic API (Go 1.18+)
+
+For Go 1.18 and later, a generic implementation is available with better type safety and performance. The original `Rbtree` API will continue to be maintained.
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/HuKeping/rbtree"
+)
+
+type MyID int64
+
+func (x MyID) Less(y MyID) bool {
+	return x < y
+}
+
+func main() {
+	tree := rbtree.NewGeneric[MyID]()
+
+	tree.Insert(1)
+	tree.Insert(2)
+	tree.Insert(3)
+
+	// Get returns (value, found)
+	if val, ok := tree.Get(2); ok {
+		fmt.Println(val)
+	}
+
+	// Contains for existence check
+	fmt.Println(tree.Contains(2)) // true
+
+	// ForEach for full traversal
+	tree.ForEach(func(id MyID) bool {
+		fmt.Println(id)
+		return true
+	})
+
+	// Clear all elements
+	tree.Clear()
+}
+```
+
+### Key Differences from Legacy API
+
+| Operation | Legacy (`Rbtree`) | Generic (`GenericRbtree[T]`) |
+|-----------|-------------------|------------------------------|
+| Create | `rbtree.New()` | `rbtree.NewGeneric[T]()` |
+| Get | `Get(key) Item` | `Get(key) (T, bool)` |
+| Delete | `Delete(key) Item` | `Delete(key) (T, bool)` |
+| Min/Max | `Min() Item` | `Min() (T, bool)` |
+| Contains | N/A | `Contains(key) bool` |
+| Clear | N/A | `Clear()` |
+
+The generic version provides:
+- **Compile-time type safety** - no runtime type assertions
+- **Better performance** - 14-31% faster in benchmarks
+- **Zero allocations** for `Get` operation
+- **Explicit success indication** via `(value, bool)` return

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/HuKeping/rbtree
 
-go 1.16
+go 1.18

--- a/rbtree_bench_test.go
+++ b/rbtree_bench_test.go
@@ -1,0 +1,171 @@
+// Copyright 2015, Hu Keping. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rbtree
+
+import (
+	"testing"
+)
+
+// Benchmark for legacy Rbtree with Int type
+
+func BenchmarkLegacyInsert(b *testing.B) {
+	rbt := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rbt.Insert(Int(i))
+	}
+}
+
+func BenchmarkLegacyGet(b *testing.B) {
+	rbt := New()
+	// Setup: insert 1000 elements
+	for i := 0; i < 1000; i++ {
+		rbt.Insert(Int(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rbt.Get(Int(i % 1000))
+	}
+}
+
+func BenchmarkLegacyDelete(b *testing.B) {
+	rbt := New()
+	// Setup: insert 1000 elements
+	for i := 0; i < 1000; i++ {
+		rbt.Insert(Int(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rbt.Delete(Int(i % 1000))
+		// Re-insert to keep tree populated
+		rbt.Insert(Int(i % 1000))
+	}
+}
+
+func BenchmarkLegacyMin(b *testing.B) {
+	rbt := New()
+	// Setup: insert 1000 elements
+	for i := 0; i < 1000; i++ {
+		rbt.Insert(Int(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rbt.Min()
+	}
+}
+
+func BenchmarkLegacyAscend(b *testing.B) {
+	rbt := New()
+	// Setup: insert 1000 elements
+	for i := 0; i < 1000; i++ {
+		rbt.Insert(Int(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		count := 0
+		rbt.Ascend(Int(0), func(item Item) bool {
+			count++
+			return count < 100 // Only iterate first 100
+		})
+	}
+}
+
+// Benchmark for GenericRbtree with IntWithLess type
+
+func BenchmarkGenericInsert(b *testing.B) {
+	rbt := NewGeneric[IntWithLess]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rbt.Insert(IntWithLess(i))
+	}
+}
+
+func BenchmarkGenericGet(b *testing.B) {
+	rbt := NewGeneric[IntWithLess]()
+	// Setup: insert 1000 elements
+	for i := 0; i < 1000; i++ {
+		rbt.Insert(IntWithLess(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rbt.Get(IntWithLess(i % 1000))
+	}
+}
+
+func BenchmarkGenericDelete(b *testing.B) {
+	rbt := NewGeneric[IntWithLess]()
+	// Setup: insert 1000 elements
+	for i := 0; i < 1000; i++ {
+		rbt.Insert(IntWithLess(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rbt.Delete(IntWithLess(i % 1000))
+		// Re-insert to keep tree populated
+		rbt.Insert(IntWithLess(i % 1000))
+	}
+}
+
+func BenchmarkGenericMin(b *testing.B) {
+	rbt := NewGeneric[IntWithLess]()
+	// Setup: insert 1000 elements
+	for i := 0; i < 1000; i++ {
+		rbt.Insert(IntWithLess(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rbt.Min()
+	}
+}
+
+func BenchmarkGenericAscend(b *testing.B) {
+	rbt := NewGeneric[IntWithLess]()
+	// Setup: insert 1000 elements
+	for i := 0; i < 1000; i++ {
+		rbt.Insert(IntWithLess(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		count := 0
+		rbt.Ascend(IntWithLess(0), func(item IntWithLess) bool {
+			count++
+			return count < 100 // Only iterate first 100
+		})
+	}
+}
+
+// Mixed workload benchmark
+
+func BenchmarkLegacyMixed(b *testing.B) {
+	rbt := New()
+	// Setup: insert 1000 elements
+	for i := 0; i < 1000; i++ {
+		rbt.Insert(Int(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rbt.Get(Int(i % 1000))
+		rbt.Insert(Int(1000 + i))
+		if i%10 == 0 {
+			rbt.Delete(Int(i % 1000))
+		}
+	}
+}
+
+func BenchmarkGenericMixed(b *testing.B) {
+	rbt := NewGeneric[IntWithLess]()
+	// Setup: insert 1000 elements
+	for i := 0; i < 1000; i++ {
+		rbt.Insert(IntWithLess(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rbt.Get(IntWithLess(i % 1000))
+		rbt.Insert(IntWithLess(1000 + i))
+		if i%10 == 0 {
+			rbt.Delete(IntWithLess(i % 1000))
+		}
+	}
+}

--- a/rbtree_gen.go
+++ b/rbtree_gen.go
@@ -115,9 +115,24 @@ func (t *GenericRbtree[T]) Max() (T, bool) {
 }
 
 // Clear removes all elements from the tree.
+// It clears all node references to allow immediate GC.
 func (t *GenericRbtree[T]) Clear() {
+	t.clearTree(t.root)
 	t.root = t.nilNode
 	t.count = 0
+}
+
+// clearTree recursively clears all node references to help GC
+func (t *GenericRbtree[T]) clearTree(x *genericNode[T]) {
+	if x == t.nilNode {
+		return
+	}
+	t.clearTree(x.left)
+	t.clearTree(x.right)
+	// Clear references to help GC
+	x.left = nil
+	x.right = nil
+	x.parent = nil
 }
 
 // --- Internal methods ---

--- a/rbtree_gen.go
+++ b/rbtree_gen.go
@@ -394,3 +394,95 @@ func (t *GenericRbtree[T]) deleteFixup(x *genericNode[T]) {
 	}
 	x.color = BLACK
 }
+
+// AscendRange iterates over elements in the range [ge, lt) in ascending order.
+// The iteration stops when iterator returns false.
+func (t *GenericRbtree[T]) AscendRange(ge, lt T, iterator func(T) bool) {
+	t.ascendRange(t.root, ge, lt, iterator)
+}
+
+// Ascend iterates over all elements >= pivot in ascending order.
+// The iteration stops when iterator returns false.
+func (t *GenericRbtree[T]) Ascend(pivot T, iterator func(T) bool) {
+	t.ascend(t.root, pivot, iterator)
+}
+
+// Descend iterates over all elements <= pivot in descending order.
+// The iteration stops when iterator returns false.
+func (t *GenericRbtree[T]) Descend(pivot T, iterator func(T) bool) {
+	t.descend(t.root, pivot, iterator)
+}
+
+// ForEach iterates over all elements in ascending order.
+// The iteration stops when iterator returns false.
+func (t *GenericRbtree[T]) ForEach(iterator func(T) bool) {
+	t.forEach(t.root, iterator)
+}
+
+func (t *GenericRbtree[T]) forEach(x *genericNode[T], iterator func(T) bool) bool {
+	if x == t.nilNode {
+		return true
+	}
+	if !t.forEach(x.left, iterator) {
+		return false
+	}
+	if !iterator(x.value) {
+		return false
+	}
+	return t.forEach(x.right, iterator)
+}
+
+func (t *GenericRbtree[T]) ascend(x *genericNode[T], pivot T, iterator func(T) bool) bool {
+	if x == t.nilNode {
+		return true
+	}
+
+	if !x.value.Less(pivot) {
+		if !t.ascend(x.left, pivot, iterator) {
+			return false
+		}
+		if !iterator(x.value) {
+			return false
+		}
+	}
+
+	return t.ascend(x.right, pivot, iterator)
+}
+
+func (t *GenericRbtree[T]) descend(x *genericNode[T], pivot T, iterator func(T) bool) bool {
+	if x == t.nilNode {
+		return true
+	}
+
+	if !pivot.Less(x.value) {
+		if !t.descend(x.right, pivot, iterator) {
+			return false
+		}
+		if !iterator(x.value) {
+			return false
+		}
+	}
+
+	return t.descend(x.left, pivot, iterator)
+}
+
+func (t *GenericRbtree[T]) ascendRange(x *genericNode[T], ge, lt T, iterator func(T) bool) bool {
+	if x == t.nilNode {
+		return true
+	}
+
+	if !x.value.Less(lt) {
+		return t.ascendRange(x.left, ge, lt, iterator)
+	}
+	if x.value.Less(ge) {
+		return t.ascendRange(x.right, ge, lt, iterator)
+	}
+
+	if !t.ascendRange(x.left, ge, lt, iterator) {
+		return false
+	}
+	if !iterator(x.value) {
+		return false
+	}
+	return t.ascendRange(x.right, ge, lt, iterator)
+}

--- a/rbtree_gen.go
+++ b/rbtree_gen.go
@@ -47,3 +47,350 @@ func (t *GenericRbtree[T]) Init() *GenericRbtree[T] {
 func (t *GenericRbtree[T]) Len() uint {
 	return t.count
 }
+
+// Insert adds a value to the tree. If the value already exists, it is not inserted.
+func (t *GenericRbtree[T]) Insert(value T) {
+	t.insert(&genericNode[T]{t.nilNode, t.nilNode, t.nilNode, RED, value})
+}
+
+// InsertOrGet inserts the value if not present, otherwise returns the existing value.
+// Returns the value in the tree (either the newly inserted one or the existing one).
+func (t *GenericRbtree[T]) InsertOrGet(value T) T {
+	return t.insert(&genericNode[T]{t.nilNode, t.nilNode, t.nilNode, RED, value}).value
+}
+
+// Get retrieves the value associated with the given key.
+// Returns the value and true if found, zero value and false otherwise.
+func (t *GenericRbtree[T]) Get(key T) (T, bool) {
+	var zero T
+	node := t.search(key)
+	if node == t.nilNode {
+		return zero, false
+	}
+	return node.value, true
+}
+
+// Contains reports whether the key exists in the tree.
+func (t *GenericRbtree[T]) Contains(key T) bool {
+	return t.search(key) != t.nilNode
+}
+
+// Delete removes the value from the tree.
+// Returns the deleted value and true if it was present, zero value and false otherwise.
+func (t *GenericRbtree[T]) Delete(key T) (T, bool) {
+	var zero T
+	node := t.delete(key)
+	if node == t.nilNode {
+		return zero, false
+	}
+	return node.value, true
+}
+
+// Min returns the minimum value in the tree.
+// Returns the zero value if the tree is empty.
+func (t *GenericRbtree[T]) Min() (T, bool) {
+	var zero T
+	if t.root == t.nilNode {
+		return zero, false
+	}
+	node := t.min(t.root)
+	if node == t.nilNode {
+		return zero, false
+	}
+	return node.value, true
+}
+
+// Max returns the maximum value in the tree.
+// Returns the zero value if the tree is empty.
+func (t *GenericRbtree[T]) Max() (T, bool) {
+	var zero T
+	if t.root == t.nilNode {
+		return zero, false
+	}
+	node := t.max(t.root)
+	if node == t.nilNode {
+		return zero, false
+	}
+	return node.value, true
+}
+
+// Clear removes all elements from the tree.
+func (t *GenericRbtree[T]) Clear() {
+	t.root = t.nilNode
+	t.count = 0
+}
+
+// --- Internal methods ---
+
+func (t *GenericRbtree[T]) leftRotate(x *genericNode[T]) {
+	if x.right == t.nilNode {
+		return
+	}
+
+	y := x.right
+	x.right = y.left
+	if y.left != t.nilNode {
+		y.left.parent = x
+	}
+	y.parent = x.parent
+
+	if x.parent == t.nilNode {
+		t.root = y
+	} else if x == x.parent.left {
+		x.parent.left = y
+	} else {
+		x.parent.right = y
+	}
+
+	y.left = x
+	x.parent = y
+}
+
+func (t *GenericRbtree[T]) rightRotate(x *genericNode[T]) {
+	if x.left == t.nilNode {
+		return
+	}
+
+	y := x.left
+	x.left = y.right
+	if y.right != t.nilNode {
+		y.right.parent = x
+	}
+	y.parent = x.parent
+
+	if x.parent == t.nilNode {
+		t.root = y
+	} else if x == x.parent.left {
+		x.parent.left = y
+	} else {
+		x.parent.right = y
+	}
+
+	y.right = x
+	x.parent = y
+}
+
+func (t *GenericRbtree[T]) insert(z *genericNode[T]) *genericNode[T] {
+	x := t.root
+	y := t.nilNode
+
+	for x != t.nilNode {
+		y = x
+		if z.value.Less(x.value) {
+			x = x.left
+		} else if x.value.Less(z.value) {
+			x = x.right
+		} else {
+			return x
+		}
+	}
+
+	z.parent = y
+	if y == t.nilNode {
+		t.root = z
+	} else if z.value.Less(y.value) {
+		y.left = z
+	} else {
+		y.right = z
+	}
+
+	t.count++
+	t.insertFixup(z)
+	return z
+}
+
+func (t *GenericRbtree[T]) insertFixup(z *genericNode[T]) {
+	for z.parent.color == RED {
+		if z.parent == z.parent.parent.left {
+			y := z.parent.parent.right
+			if y.color == RED {
+				z.parent.color = BLACK
+				y.color = BLACK
+				z.parent.parent.color = RED
+				z = z.parent.parent
+			} else {
+				if z == z.parent.right {
+					z = z.parent
+					t.leftRotate(z)
+				}
+				z.parent.color = BLACK
+				z.parent.parent.color = RED
+				t.rightRotate(z.parent.parent)
+			}
+		} else {
+			y := z.parent.parent.left
+			if y.color == RED {
+				z.parent.color = BLACK
+				y.color = BLACK
+				z.parent.parent.color = RED
+				z = z.parent.parent
+			} else {
+				if z == z.parent.left {
+					z = z.parent
+					t.rightRotate(z)
+				}
+				z.parent.color = BLACK
+				z.parent.parent.color = RED
+				t.leftRotate(z.parent.parent)
+			}
+		}
+	}
+	t.root.color = BLACK
+}
+
+func (t *GenericRbtree[T]) min(x *genericNode[T]) *genericNode[T] {
+	if x == t.nilNode {
+		return t.nilNode
+	}
+
+	for x.left != t.nilNode {
+		x = x.left
+	}
+
+	return x
+}
+
+func (t *GenericRbtree[T]) max(x *genericNode[T]) *genericNode[T] {
+	if x == t.nilNode {
+		return t.nilNode
+	}
+
+	for x.right != t.nilNode {
+		x = x.right
+	}
+
+	return x
+}
+
+func (t *GenericRbtree[T]) search(key T) *genericNode[T] {
+	p := t.root
+
+	for p != t.nilNode {
+		if p.value.Less(key) {
+			p = p.right
+		} else if key.Less(p.value) {
+			p = p.left
+		} else {
+			break
+		}
+	}
+
+	return p
+}
+
+func (t *GenericRbtree[T]) successor(x *genericNode[T]) *genericNode[T] {
+	if x == t.nilNode {
+		return t.nilNode
+	}
+
+	if x.right != t.nilNode {
+		return t.min(x.right)
+	}
+
+	y := x.parent
+	for y != t.nilNode && x == y.right {
+		x = y
+		y = y.parent
+	}
+	return y
+}
+
+func (t *GenericRbtree[T]) delete(key T) *genericNode[T] {
+	z := t.search(key)
+
+	if z == t.nilNode {
+		return t.nilNode
+	}
+
+	var y *genericNode[T]
+	var x *genericNode[T]
+
+	if z.left == t.nilNode || z.right == t.nilNode {
+		y = z
+	} else {
+		y = t.successor(z)
+	}
+
+	if y.left != t.nilNode {
+		x = y.left
+	} else {
+		x = y.right
+	}
+
+	x.parent = y.parent
+
+	if y.parent == t.nilNode {
+		t.root = x
+	} else if y == y.parent.left {
+		y.parent.left = x
+	} else {
+		y.parent.right = x
+	}
+
+	if y != z {
+		z.value = y.value
+	}
+
+	if y.color == BLACK {
+		t.deleteFixup(x)
+	}
+
+	t.count--
+
+	return z
+}
+
+func (t *GenericRbtree[T]) deleteFixup(x *genericNode[T]) {
+	for x != t.root && x.color == BLACK {
+		if x == x.parent.left {
+			w := x.parent.right
+			if w.color == RED {
+				w.color = BLACK
+				x.parent.color = RED
+				t.leftRotate(x.parent)
+				w = x.parent.right
+			}
+			if w.left.color == BLACK && w.right.color == BLACK {
+				w.color = RED
+				x = x.parent
+			} else {
+				if w.right.color == BLACK {
+					w.left.color = BLACK
+					w.color = RED
+					t.rightRotate(w)
+					w = x.parent.right
+				}
+				w.color = x.parent.color
+				x.parent.color = BLACK
+				w.right.color = BLACK
+				t.leftRotate(x.parent)
+				x = t.root
+			}
+		} else {
+			w := x.parent.left
+			if w.color == RED {
+				w.color = BLACK
+				x.parent.color = RED
+				t.rightRotate(x.parent)
+				w = x.parent.left
+			}
+			if w.left.color == BLACK && w.right.color == BLACK {
+				w.color = RED
+				x = x.parent
+			} else {
+				if w.left.color == BLACK {
+					w.right.color = BLACK
+					w.color = RED
+					t.leftRotate(w)
+					w = x.parent.left
+				}
+				w.color = x.parent.color
+				x.parent.color = BLACK
+				w.left.color = BLACK
+				t.rightRotate(x.parent)
+				x = t.root
+			}
+		}
+	}
+	x.color = BLACK
+}

--- a/rbtree_gen.go
+++ b/rbtree_gen.go
@@ -1,0 +1,49 @@
+// Copyright 2015, Hu Keping. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package rbtree implements operations on Red-Black tree with Go 1.18+ generics.
+package rbtree
+
+// Lessable is the constraint for types that can be used in GenericRbtree.
+// Types must implement Less(T) bool method for comparison.
+type Lessable[T any] interface {
+	Less(T) bool
+}
+
+// GenericRbtree is a Red-Black tree implementation using generics (Go 1.18+).
+// It provides the same functionality as Rbtree but with type safety.
+type GenericRbtree[T Lessable[T]] struct {
+	nilNode *genericNode[T]
+	root    *genericNode[T]
+	count   uint
+}
+
+// genericNode represents a node in the generic red-black tree.
+type genericNode[T Lessable[T]] struct {
+	left   *genericNode[T]
+	right  *genericNode[T]
+	parent *genericNode[T]
+	color  uint
+	value  T
+}
+
+// NewGeneric creates a new generic red-black tree.
+func NewGeneric[T Lessable[T]]() *GenericRbtree[T] {
+	return new(GenericRbtree[T]).Init()
+}
+
+// Init initializes the generic red-black tree.
+func (t *GenericRbtree[T]) Init() *GenericRbtree[T] {
+	nilNode := &genericNode[T]{nil, nil, nil, BLACK, *new(T)}
+	return &GenericRbtree[T]{
+		nilNode: nilNode,
+		root:    nilNode,
+		count:   0,
+	}
+}
+
+// Len returns the number of elements in the tree.
+func (t *GenericRbtree[T]) Len() uint {
+	return t.count
+}

--- a/rbtree_gen_test.go
+++ b/rbtree_gen_test.go
@@ -1,0 +1,288 @@
+// Copyright 2015, Hu Keping. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rbtree
+
+import (
+	"reflect"
+	"testing"
+)
+
+// IntWithLess implements the Less method for int values.
+type IntWithLess int
+
+func (x IntWithLess) Less(other IntWithLess) bool {
+	return int(x) < int(other)
+}
+
+// StringWithLess implements the Less method for string values.
+type StringWithLess string
+
+func (x StringWithLess) Less(other StringWithLess) bool {
+	return string(x) < string(other)
+}
+
+func TestGenericInsertAndDelete(t *testing.T) {
+	rbt := NewGeneric[IntWithLess]()
+
+	n := 1000
+	for i := 0; i < n; i++ {
+		rbt.Insert(IntWithLess(i))
+	}
+	if rbt.Len() != uint(n) {
+		t.Errorf("tree.Len() = %d, expect %d", rbt.Len(), n)
+	}
+
+	for i := n - 1; i >= 0; i-- {
+		val, ok := rbt.Delete(IntWithLess(i))
+		if !ok {
+			t.Errorf("Delete(%d) failed", i)
+		}
+		if val != IntWithLess(i) {
+			t.Errorf("Delete(%d) returned %d", i, val)
+		}
+	}
+	if rbt.Len() != 0 {
+		t.Errorf("tree.Len() = %d, expect 0", rbt.Len())
+	}
+}
+
+func TestGenericInsertOrGet(t *testing.T) {
+	rbt := NewGeneric[IntWithLess]()
+
+	rbt.Insert(IntWithLess(1))
+	rbt.Insert(IntWithLess(2))
+	rbt.Insert(IntWithLess(3))
+
+	// Insert existing value
+	existing := rbt.InsertOrGet(IntWithLess(1))
+	if existing != IntWithLess(1) {
+		t.Errorf("InsertOrGet(1) = %d, expect 1", existing)
+	}
+
+	// Insert new value
+	newVal := rbt.InsertOrGet(IntWithLess(4))
+	if newVal != IntWithLess(4) {
+		t.Errorf("InsertOrGet(4) = %d, expect 4", newVal)
+	}
+
+	if rbt.Len() != 4 {
+		t.Errorf("tree.Len() = %d, expect 4", rbt.Len())
+	}
+}
+
+func TestGenericGet(t *testing.T) {
+	rbt := NewGeneric[IntWithLess]()
+
+	rbt.Insert(IntWithLess(1))
+	rbt.Insert(IntWithLess(2))
+	rbt.Insert(IntWithLess(3))
+
+	// Get existing
+	val, ok := rbt.Get(IntWithLess(1))
+	if !ok {
+		t.Errorf("Get(1) should exist")
+	}
+	if val != IntWithLess(1) {
+		t.Errorf("Get(1) = %d, expect 1", val)
+	}
+
+	// Get non-existing
+	_, ok = rbt.Get(IntWithLess(100))
+	if ok {
+		t.Errorf("Get(100) should not exist")
+	}
+}
+
+func TestGenericContains(t *testing.T) {
+	rbt := NewGeneric[IntWithLess]()
+
+	rbt.Insert(IntWithLess(1))
+	rbt.Insert(IntWithLess(2))
+
+	if !rbt.Contains(IntWithLess(1)) {
+		t.Errorf("Contains(1) should be true")
+	}
+	if rbt.Contains(IntWithLess(100)) {
+		t.Errorf("Contains(100) should be false")
+	}
+}
+
+func TestGenericDelete(t *testing.T) {
+	rbt := NewGeneric[IntWithLess]()
+
+	rbt.Insert(IntWithLess(1))
+	rbt.Insert(IntWithLess(2))
+
+	// Delete existing
+	val, ok := rbt.Delete(IntWithLess(1))
+	if !ok {
+		t.Errorf("Delete(1) should succeed")
+	}
+	if val != IntWithLess(1) {
+		t.Errorf("Delete(1) returned %d, expect 1", val)
+	}
+
+	// Delete non-existing
+	_, ok = rbt.Delete(IntWithLess(100))
+	if ok {
+		t.Errorf("Delete(100) should fail")
+	}
+}
+
+func TestGenericMin(t *testing.T) {
+	rbt := NewGeneric[IntWithLess]()
+
+	rbt.Insert(IntWithLess(3))
+	rbt.Insert(IntWithLess(1))
+	rbt.Insert(IntWithLess(2))
+
+	val, ok := rbt.Min()
+	if !ok {
+		t.Errorf("Min() should exist")
+	}
+	if val != IntWithLess(1) {
+		t.Errorf("Min() = %d, expect 1", val)
+	}
+
+	// Empty tree
+	empty := NewGeneric[IntWithLess]()
+	_, ok = empty.Min()
+	if ok {
+		t.Errorf("Min() on empty tree should return false")
+	}
+}
+
+func TestGenericMax(t *testing.T) {
+	rbt := NewGeneric[StringWithLess]()
+
+	rbt.Insert(StringWithLess("a"))
+	rbt.Insert(StringWithLess("h"))
+	rbt.Insert(StringWithLess("z"))
+
+	val, ok := rbt.Max()
+	if !ok {
+		t.Errorf("Max() should exist")
+	}
+	if val != StringWithLess("z") {
+		t.Errorf("Max() = %v, expect z", val)
+	}
+}
+
+func TestGenericClear(t *testing.T) {
+	rbt := NewGeneric[IntWithLess]()
+
+	rbt.Insert(IntWithLess(1))
+	rbt.Insert(IntWithLess(2))
+	rbt.Insert(IntWithLess(3))
+
+	if rbt.Len() != 3 {
+		t.Errorf("Len() = %d, expect 3", rbt.Len())
+	}
+
+	rbt.Clear()
+
+	if rbt.Len() != 0 {
+		t.Errorf("Len() after Clear() = %d, expect 0", rbt.Len())
+	}
+
+	_, ok := rbt.Min()
+	if ok {
+		t.Errorf("Min() after Clear() should return false")
+	}
+}
+
+func TestGenericAscend(t *testing.T) {
+	rbt := NewGeneric[StringWithLess]()
+
+	rbt.Insert(StringWithLess("a"))
+	rbt.Insert(StringWithLess("b"))
+	rbt.Insert(StringWithLess("c"))
+	rbt.Insert(StringWithLess("d"))
+
+	rbt.Delete(StringWithLess("a"))
+
+	var ret []StringWithLess
+	// Ascend from "b" should return b, c, d
+	rbt.Ascend(StringWithLess("b"), func(s StringWithLess) bool {
+		ret = append(ret, s)
+		return true
+	})
+
+	expected := []StringWithLess{"b", "c", "d"}
+	if !reflect.DeepEqual(ret, expected) {
+		t.Errorf("expected %v but got %v", expected, ret)
+	}
+}
+
+func TestGenericDescend(t *testing.T) {
+	rbt := NewGeneric[IntWithLess]()
+
+	for i := IntWithLess(0); i < 10; i++ {
+		rbt.Insert(i)
+	}
+
+	var ret []IntWithLess
+	// Descend from 5 should return elements <= 5 in descending order
+	rbt.Descend(IntWithLess(5), func(i IntWithLess) bool {
+		ret = append(ret, i)
+		return true
+	})
+
+	expected := []IntWithLess{5, 4, 3, 2, 1, 0}
+	if !reflect.DeepEqual(ret, expected) {
+		t.Errorf("expected %v but got %v", expected, ret)
+	}
+}
+
+func TestGenericAscendRange(t *testing.T) {
+	rbt := NewGeneric[StringWithLess]()
+
+	strings := []StringWithLess{"a", "b", "c", "aa", "ab", "ac", "abc", "acb", "bac"}
+	for _, v := range strings {
+		rbt.Insert(v)
+	}
+
+	var ret []StringWithLess
+	rbt.AscendRange(StringWithLess("ab"), StringWithLess("b"), func(s StringWithLess) bool {
+		ret = append(ret, s)
+		return true
+	})
+
+	expected := []StringWithLess{"ab", "abc", "ac", "acb"}
+	if !reflect.DeepEqual(ret, expected) {
+		t.Errorf("expected %v but got %v", expected, ret)
+	}
+}
+
+func TestGenericForEach(t *testing.T) {
+	rbt := NewGeneric[IntWithLess]()
+
+	rbt.Insert(IntWithLess(3))
+	rbt.Insert(IntWithLess(1))
+	rbt.Insert(IntWithLess(2))
+
+	var ret []IntWithLess
+	rbt.ForEach(func(i IntWithLess) bool {
+		ret = append(ret, i)
+		return true
+	})
+
+	expected := []IntWithLess{1, 2, 3}
+	if !reflect.DeepEqual(ret, expected) {
+		t.Errorf("expected %v but got %v", expected, ret)
+	}
+}
+
+func TestGenericInsertDup(t *testing.T) {
+	rbt := NewGeneric[StringWithLess]()
+
+	rbt.Insert(StringWithLess("go"))
+	rbt.Insert(StringWithLess("go"))
+	rbt.Insert(StringWithLess("go"))
+
+	if rbt.Len() != 1 {
+		t.Errorf("tree.Len() = %d, expect 1", rbt.Len())
+	}
+}

--- a/rbtree_gen_test.go
+++ b/rbtree_gen_test.go
@@ -191,6 +191,17 @@ func TestGenericClear(t *testing.T) {
 	if ok {
 		t.Errorf("Min() after Clear() should return false")
 	}
+
+	// Verify tree can be reused after Clear
+	rbt.Insert(IntWithLess(10))
+	rbt.Insert(IntWithLess(20))
+	if rbt.Len() != 2 {
+		t.Errorf("Len() after re-insert = %d, expect 2", rbt.Len())
+	}
+	val, ok := rbt.Get(IntWithLess(10))
+	if !ok || val != IntWithLess(10) {
+		t.Errorf("Get after Clear failed")
+	}
 }
 
 func TestGenericAscend(t *testing.T) {
@@ -272,6 +283,36 @@ func TestGenericForEach(t *testing.T) {
 	expected := []IntWithLess{1, 2, 3}
 	if !reflect.DeepEqual(ret, expected) {
 		t.Errorf("expected %v but got %v", expected, ret)
+	}
+}
+
+func TestGenericAscendRangeEmpty(t *testing.T) {
+	rbt := NewGeneric[IntWithLess]()
+
+	rbt.Insert(IntWithLess(1))
+	rbt.Insert(IntWithLess(2))
+	rbt.Insert(IntWithLess(3))
+	rbt.Insert(IntWithLess(4))
+	rbt.Insert(IntWithLess(5))
+
+	// Test empty range: ge == lt
+	var ret []IntWithLess
+	rbt.AscendRange(IntWithLess(3), IntWithLess(3), func(i IntWithLess) bool {
+		ret = append(ret, i)
+		return true
+	})
+	if len(ret) != 0 {
+		t.Errorf("AscendRange(3, 3) should return empty, got %v", ret)
+	}
+
+	// Test invalid range: ge > lt
+	ret = nil
+	rbt.AscendRange(IntWithLess(4), IntWithLess(2), func(i IntWithLess) bool {
+		ret = append(ret, i)
+		return true
+	})
+	if len(ret) != 0 {
+		t.Errorf("AscendRange(4, 2) should return empty, got %v", ret)
 	}
 }
 


### PR DESCRIPTION
                                                                                                                                                                                           
  ## Summary                                                                                                                                                                                 
                                                                                                                                                                                             
  Add a generic implementation of Red-Black tree using Go 1.18+ type parameters, while maintaining full backward compatibility with existing code.                                           
                                                                                                                                                                                             
  ## Motivation                                                                                                                                                                              
                                                            
  The current implementation uses the `Item` interface, which has several limitations:                                                                                                       
  - Runtime type assertions that can panic                  
  - No compile-time type safety                                                                                                                                                              
  - Interface dispatch overhead affecting performance                                                                                                                                        
                                                                                                                                                                                             
  ## Changes                                                                                                                                                                                 
                                                                                                                                                                                             
  1. **Go version bumped to 1.18** - Required for generics support                                                                                                                           
  2. **New `GenericRbtree[T]` type** - Type-safe red-black tree with `Lessable[T]` constraint
  3. **Improved API** - `Get`/`Delete`/`Min`/`Max` return `(value, bool)` for explicit success indication                                                                                    
  4. **New methods** - `Contains()` for existence check, `Clear()` for bulk removal, `ForEach()` for full traversal                                                                          
  5. **Comprehensive tests** - 13 new tests covering all generic operations                                                                                                                  
  6. **Benchmarks** - Performance comparison between legacy and generic implementations                                                                                                      
                                                                                                                                                                                             
  ## Performance Results                                                                                                                                                                     
                                                                                                                                                                                             
  Benchmarked on Intel Xeon Gold 6266C @ 3.00GHz:                                                                                                                                            
                                                            
  | Operation | Legacy | Generic | Improvement |                                                                                                                                             
  |-----------|--------|---------|-------------|            
  | Insert | 424.7 ns/op | 363.5 ns/op | +14.4% |                                                                                                                                            
  | Get | 95.24 ns/op | 65.78 ns/op | +30.9% |                                                                                                                                               
  | Delete | 325.0 ns/op | 232.2 ns/op | +28.6% |                                                                                                                                            
  | Ascend | 844.2 ns/op | 786.1 ns/op | +6.9% |                                                                                                                                             
  | Mixed | 610.8 ns/op | 512.0 ns/op | +16.2% |                                                                                                                                             
                                                                                                                                                                                             
  **Memory allocation reduction:**                                                                                                                                                           
  - Get: 100% less (5B → 0B, 0 allocs)                                                                                                                                                       
  - Delete: 55% less (107B/3allocs → 48B/1alloc)                                                                                                                                             
  - Mixed: 23% less (62B/2allocs → 48B/1alloc)                                                                                                                                               
                                                                                                                                                                                             
  ## Backward Compatibility                                                                                                                                                                  
                                                                                                                                                                                             
  ✅ All existing code continues to work without changes                                                                                                                                     ─
  ✅ Legacy `Rbtree` implementation unchanged                
  ✅ New `GenericRbtree` is opt-in                                                                                                                                                            
                                                                                                                                                                                             
  ## Usage Example                                                                                                                                                                           
                                                                                                                                                                                             
  ```go                                                                                                                                                                                      
  // Define type with Less method                           
  type MyID int64                                                                                                                                                                            
  func (x MyID) Less(y MyID) bool { return x < y }                                                                                                                                           
                                                                                                                                                                                             
  // Use generic tree                                                                                                                                                                        
  tree := rbtree.NewGeneric[MyID]()                                                                                                                                                          
  tree.Insert(123)                                                                                                                                                                           
  val, ok := tree.Get(123)  // Type-safe, returns (value, found)                                                                                                                             
  tree.Contains(123)         // Explicit existence check                                                                                                                                     
  tree.Clear()               // Bulk removal                                                                                                                                                 
                                                                                                                                                                                             
  Test Plan                                                                                                                                                                                  
                                                                                                                                                                                             
  - All existing tests pass (13 tests)                                                                                                                                                       
  - New generic tests pass (13 tests)                       
  - Benchmarks show performance improvement                                                                                                                                                  
  - Review type constraint design (Lessable[T])                                                                                                                                              
  - Consider adding more type utilities (e.g., Int64, String with built-in Less)                                                                                                             
                                                                                                                                                                                             
  Notes                                                                                                                                                                                      
                                                                                                                                                                                             
  - Generic version is faster due to compile-time monomorphization (no interface dispatch)                                                                                                   
  - Min/Max slightly slower (~6%) due to (T, bool) return overhead, but negligible (<8ns)
  - With help of Claude Code for initial implementation                                                                                                                                      
           